### PR TITLE
Fixes #2 - Do not attempt to marshal the payload into a hash unless it is an array.

### DIFF
--- a/lib/redis/stream/wrapper.rb
+++ b/lib/redis/stream/wrapper.rb
@@ -1,4 +1,5 @@
 require 'dry-struct'
+require 'redis/stream/wrapper/message'
 class Redis
   module Stream
     class Wrapper
@@ -140,11 +141,19 @@ class Redis
           messages.map do |id, payload|
             Message.new(
               stream: stream_name,
-              payload: Hash[payload.each_slice(2).to_a],
+              payload: parse_payload(payload),
               id: id
             )
           end
         end.flatten.compact
+      end
+
+      def parse_payload(payload)
+        if payload.is_a? Array
+          Hash[payload.each_slice(2).to_a]
+        else
+          payload
+        end
       end
 
       # Returns a copy of the current instance, with the id set.

--- a/spec/redis/stream/wrapper_spec.rb
+++ b/spec/redis/stream/wrapper_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 RSpec.describe Redis::Stream::Wrapper do
 
   let(:stream_name) { "stream-test" }
+  let(:array_payload) { %w[foo bar woo xoo] }
   let(:payload) { { "foo" => "bar", "woo" => "xoo" } }
   let(:group) { "test-group" }
   let(:message_without_id) { ::Redis::Stream::Wrapper::Message.new(stream: stream_name, payload: payload) }
@@ -76,5 +77,15 @@ RSpec.describe Redis::Stream::Wrapper do
     expect(resp).to be_a(Hash)
     resp = wrapper_instance.info(:groups, message_without_id.stream)
     expect(resp).to be_a(Array)
+  end
+
+  it "should parse array payloads into Hash" do
+    resp = wrapper_instance.send(:parse_payload, array_payload)
+    expect(resp).to match(payload)
+  end
+
+  it "should not parse Hash payloads" do
+    resp = wrapper_instance.send(:parse_payload, payload)
+    expect(resp).to match(payload)
   end
 end


### PR DESCRIPTION
In the latest version of the Redis gem, the payload after an `xreadgroup` is a `Hash`. When `wrapper.rb` is creating `Message`s, it assumes the payload is an `Array`.